### PR TITLE
swapped dotenv .load() with .config()

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ const FILE_LOCATION_URL =
   'https://api.github.com/repos/jsjoeio/100-days-twilio-twitter/contents/logs.md'
 
 if (process.env.NODE_ENV !== 'production') {
-  require('dotenv').load()
+  require('dotenv').config()
 }
 
 /* Twitter API */


### PR DESCRIPTION
Have swapper the dotenv .load() with .config() due to error being given when app being run. 
Error given was "Load() is not a function". 
